### PR TITLE
fix: Update Gemini model to a current version

### DIFF
--- a/lib/aiService.ts
+++ b/lib/aiService.ts
@@ -13,7 +13,8 @@ if (!process.env.GOOGLE_GEMINI_API_KEY) {
  * @returns A promise that resolves to a string containing a JSON array of events.
  */
 export async function getAiGeneratedEvents(locationName: string): Promise<string> {
-  const model = genAI.getGenerativeModel({ model: "gemini-pro" });
+  // Use a more recent and available model. "gemini-1.5-flash-latest" is a great choice for speed and capability.
+  const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
 
   const prompt = `
     You are a geoscientist data analyst. Based on the location "${locationName}", list up to 5 of the most significant environmental or geographical events that have occurred there since 1999.


### PR DESCRIPTION
Updates the AI model in `aiService` from the deprecated `gemini-pro` to `gemini-1.5-flash-latest` to resolve a 404 error when calling the Google Generative AI API.