### PR TITLE
fix: Add cleanup for AI-generated JSON responses

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -11,8 +11,10 @@ export async function POST(request: Request) {
 
     const aiResponse = await getAiGeneratedEvents(locationName);
 
-    // The AI is prompted to return a raw JSON string, so we parse it here.
-    const events = JSON.parse(aiResponse);
+    // The AI is prompted to return a raw JSON string, but sometimes includes markdown.
+    // We'll clean the response to ensure it's valid JSON.
+    const cleanedResponse = aiResponse.replace(/```json/g, '').replace(/```/g, '').trim();
+    const events = JSON.parse(cleanedResponse);
 
     return NextResponse.json(events);
   } catch (error) {


### PR DESCRIPTION
- Modifies the /api/events route to strip markdown code blocks (```json) from the AI's response before parsing.
- This prevents JSON.parse() from failing when the AI, despite prompts, wraps its output in markdown.