### PR TITLE
fix: Resolve timeout errors and UI layering bug

### DIFF
--- a/app/maps/page.tsx
+++ b/app/maps/page.tsx
@@ -207,7 +207,7 @@ export default function MapsPage() {
 
       {/* Animation Dialog */}
       <Dialog open={isDialogOpen} onOpenChange={closeDialog}>
-        <DialogContent>
+        <DialogContent className="z-[5000]">
           <DialogHeader>
             <DialogTitle>Generating Animation</DialogTitle>
           </DialogHeader>

--- a/lib/animationService.ts
+++ b/lib/animationService.ts
@@ -18,7 +18,8 @@ interface AnimationParams {
 // Helper to download an image, creating a blank tile on 404
 async function downloadImage(url: string, filepath: string) {
   try {
-    const response = await fetch(url);
+    // Increase the timeout to 30 seconds to handle slow responses from NASA's server
+    const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
     if (!response.ok) {
       if (response.status === 404) {
         console.warn(`Image not found (404): ${url}. Creating a blank tile.`);


### PR DESCRIPTION
This commit addresses two critical issues:

1.  Increases the fetch timeout in the animation service to 30 seconds to prevent `ConnectTimeoutError` when downloading satellite images from NASA's GIBS server.
2.  Applies a high `z-index` to the animation dialog to ensure it renders on top of the map component, fixing a UI layering bug.