### PR TITLE
feat: Increase MAX_TILES limit to 5,000

### DIFF
--- a/lib/animationService.ts
+++ b/lib/animationService.ts
@@ -82,7 +82,7 @@ export async function createAnimation({ jobId, boundingBox, startDate, endDate }
 
     // --- CRITICAL SAFEGUARDS ---
     const MAX_DAYS = 31; // Limit animations to one month
-    const MAX_TILES = 2000; // Limit total images to prevent server overload
+    const MAX_TILES = 5000; // Limit total images to prevent server overload
 
     if (dates.length > MAX_DAYS) {
       throw new Error(`Date range too large. Please select a period of ${MAX_DAYS} days or less.`);


### PR DESCRIPTION
- Increases the maximum number of tiles allowed for a single animation job from 2,000 to 5,000.
- This provides more flexibility for generating animations over larger areas or longer date ranges, while still protecting against system-crashing requests.