### PR TITLE
fix: Create blank tiles on any download failure

### DIFF
--- a/lib/animationService.ts
+++ b/lib/animationService.ts
@@ -52,8 +52,10 @@ async function downloadImage(url: string, filepath: string) {
     const buffer = await response.arrayBuffer();
     await fs.writeFile(filepath, Buffer.from(buffer));
   } catch (error) {
-    console.error(`Error in downloadImage for ${url}:`, error);
-    throw error;
+    // If ANY error occurs during download (timeout, network issue, etc.),
+    // log it and create a blank tile to prevent the entire job from failing.
+    console.warn(`Download failed for ${url}: ${(error as Error).message}. Creating a blank tile.`);
+    await sharp({ create: { width: 512, height: 512, channels: 3, background: { r: 0, g: 0, b: 0 } } }).jpeg().toFile(filepath);
   }
 }
 


### PR DESCRIPTION
- Modifies the `downloadImage` helper to create a blank tile on ANY download error (e.g., timeouts, network failures), not just 404 errors.
- This prevents a critical bug where a timed-out download would result in a missing file, causing the `sharp` library to crash with an 'Input file is missing' error.
- This change makes the entire animation process significantly more resilient to network instability and ensures that jobs can complete even if some tiles fail to download.