### PR TITLE
fix: Correct ffmpeg command for final video stitching

### DIFF
--- a/lib/animationService.ts
+++ b/lib/animationService.ts
@@ -174,7 +174,7 @@ export async function createAnimation({ jobId, boundingBox, startDate, endDate }
     await new Promise<void>((resolve, reject) => {
       ffmpegCommand
         .complexFilter(finalComplexFilter.join(''))
-        .outputOptions('-map "[v]"')
+        // The -map option is not needed here, as the complex filter defines the final output stream [v]
         .on('end', resolve)
         .on('error', reject)
         .save(animationOutputPath);


### PR DESCRIPTION
- Removes the redundant and incorrect `-map "[v]"` output option from the final ffmpeg stitching command.
- This option was causing ffmpeg to fail with an 'Invalid argument' error when combining the batch-processed video clips.
- The complex filter already defines the output stream, so the explicit mapping was unnecessary and incorrect.