### PR TITLE
fix: Scale final animation to prevent 'Result too large' error

### DIFF
--- a/lib/animationService.ts
+++ b/lib/animationService.ts
@@ -163,7 +163,8 @@ export async function createAnimation({ jobId, boundingBox, startDate, endDate }
     for (let row = 0; row < numBatchRows; row++) {
         finalComplexFilter.push(`[row${row}]`);
     }
-    finalComplexFilter.push(`vstack=${numBatchRows}[v]`);
+    // After stacking all rows, add a final scaling filter to ensure the output is a reasonable size.
+    finalComplexFilter.push(`vstack=${numBatchRows},scale=1024:-1[v]`);
 
     const ffmpegCommand = ffmpeg();
     batchClipPaths.flat().forEach(p => ffmpegCommand.input(p));


### PR DESCRIPTION
- Adds a `scale=1024:-1` filter to the final ffmpeg stitching command.
- This ensures the final output GIF is scaled to a web-friendly width of 1024px, preventing ffmpeg from failing with a 'Result too large' error on massive geographical areas.
- This error was due to the inherent file size limitations of the GIF format itself.
- This change is the final step in making the batch processing engine fully robust.