### PR TITLE
feat: Switch animation output from GIF to MP4

### DIFF
--- a/app/maps/page.tsx
+++ b/app/maps/page.tsx
@@ -221,7 +221,16 @@ export default function MapsPage() {
             {jobStatus === 'complete' && animationUrl && (
               <div>
                 <h3 className="text-lg font-medium mb-2">Animation Ready!</h3>
-                <img src={animationUrl} alt="Generated Animation" className="w-full rounded-md" />
+                <video
+                  src={animationUrl}
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                  className="w-full rounded-md"
+                >
+                  Your browser does not support the video tag.
+                </video>
               </div>
             )}
             {jobStatus === 'failed' && (

--- a/lib/animationService.ts
+++ b/lib/animationService.ts
@@ -169,19 +169,20 @@ export async function createAnimation({ jobId, boundingBox, startDate, endDate }
     const ffmpegCommand = ffmpeg();
     batchClipPaths.flat().forEach(p => ffmpegCommand.input(p));
 
-    const animationOutputPath = path.join(process.cwd(), 'public', 'animations', `${jobId}.gif`);
+    const animationOutputPath = path.join(process.cwd(), 'public', 'animations', `${jobId}.mp4`);
     await fs.mkdir(path.dirname(animationOutputPath), { recursive: true });
 
     await new Promise<void>((resolve, reject) => {
       ffmpegCommand
         .complexFilter(finalComplexFilter.join(''))
-        // The -map option is not needed here, as the complex filter defines the final output stream [v]
+        // Use libx264 for MP4 encoding, the standard for web video.
+        .outputOptions(['-c:v libx264', '-pix_fmt yuv420p'])
         .on('end', resolve)
         .on('error', reject)
         .save(animationOutputPath);
     });
 
-    const animationPath = `/animations/${jobId}.gif`;
+    const animationPath = `/animations/${jobId}.mp4`;
     jobs.set(jobId, { status: 'complete', url: animationPath });
     console.log(`[${jobId}] Animation complete: ${animationPath}`);
 


### PR DESCRIPTION
- Updates the animation service to generate MP4 videos instead of GIFs to handle large-dimension outputs and improve quality.
- Modifies the frontend dialog to use a `<video>` tag instead of an `<img>` tag to correctly display the new format.
- This change resolves the 'Result too large' error that occurred with the GIF format on very large animations.