### PR TITLE
fix: Correct GEE task status request format

### DIFF
--- a/app/api/gee/status/route.ts
+++ b/app/api/gee/status/route.ts
@@ -22,7 +22,8 @@ export async function GET(request: Request) {
   try {
     // Get the status of the GEE task
     const taskStatus = await new Promise((resolve, reject) => {
-      ee.data.getTaskStatus({ name: `projects/earthengine-legacy/operations/${jobInfo.geeTaskId}` }, (status: any, err: any) => {
+      const fullTaskId = `projects/earthengine-legacy/operations/${jobInfo.geeTaskId}`;
+      ee.data.getTaskStatus(fullTaskId, (status: any, err: any) => {
         if (err) {
           return reject(err);
         }


### PR DESCRIPTION
- Fixes a critical bug where the application was failing to poll for GEE task status due to an incorrect request format.
- The `ee.data.getTaskStatus` call was incorrectly passing an object `{ name: ... }` instead of a simple string for the task ID.
- This change corrects the call to pass the task ID string directly, resolving the 'Invalid value: expected a string' error.