### PR TITLE
fix: Add defensive check for GEE task status

### DIFF
--- a/app/api/gee/status/route.ts
+++ b/app/api/gee/status/route.ts
@@ -31,7 +31,13 @@ export async function GET(request: Request) {
       });
     });
 
-    const status = (taskStatus as any).state;
+    const status = (taskStatus as any)?.state;
+
+    // If the state is not yet available, treat it as 'running' to allow polling to continue.
+    if (!status) {
+      return NextResponse.json({ status: 'running' });
+    }
+
     let response: any = { status: status.toLowerCase() }; // e.g., 'running', 'completed'
 
     if (status === 'COMPLETED') {


### PR DESCRIPTION
- Fixes a critical bug where the application would crash if the GEE task status response did not yet contain a 'state' field.
- The status polling endpoint now safely handles this case by treating a missing state as 'running', allowing polling to continue without crashing.
- This resolves the `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` and makes the status checking fully robust.